### PR TITLE
Get all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.1
+
+* Added `Amico.all(id, type, scope)` to retrieve all of the individuals for a given id, type (e.g. following) and scope. Thanks to @mettadore for the initial code and inspiration.
+
 # 2.0.0
 
 * Added `Amico.default_scope_key` and `scope` parameter to all of the methods to allow you to scope the calls to express relationships for different types of things

--- a/README.md
+++ b/README.md
@@ -398,6 +398,20 @@ Amico.following(1, {:page_size => Amico.page_size, :page => 1}, 'project')
  => ["11"]
 ```
 
+You can retrieve all of a particular type of relationship using the `all(id, type, scope)` call. For example:
+
+```ruby
+Amico.follow(1, 11)
+ => nil 
+Amico.follow(1, 12)
+ => nil 
+Amico.all(1, :following)
+ => ["12", "11"] 
+```
+
+`type` can be one of :following, :followers, :blocked, :reciprocated, :pending. Use this with caution 
+as there may potentially be a large number of items that could be returned from this call. 
+
 ## Documentation 
 
 The source for the [relationships module](https://github.com/agoragames/amico/blob/master/lib/amico/relationships.rb) is well-documented. There are some 

--- a/lib/amico/relationships.rb
+++ b/lib/amico/relationships.rb
@@ -6,7 +6,7 @@ module Amico
     # 
     # @param from_id [String] The ID of the individual establishing the follow relationship.
     # @param to_id [String] The ID of the individual to be followed.
-    # @param scope [String] Scope for the call
+    # @param scope [String] Scope for the call.
     #
     # Examples
     #
@@ -29,7 +29,7 @@ module Amico
     #
     # @param from_id [String] The ID of the individual removing the follow relationship.
     # @param to_id [String] The ID of the individual to be unfollowed.
-    # @param scope [String] Scope for the call
+    # @param scope [String] Scope for the call.
     # 
     # Examples
     #
@@ -52,7 +52,7 @@ module Amico
     #
     # @param from_id [String] The ID of the individual blocking the relationship.
     # @param to_id [String] The ID of the individual being blocked.
-    # @param scope [String] Scope for the call
+    # @param scope [String] Scope for the call.
     #
     # Examples
     #
@@ -76,7 +76,7 @@ module Amico
     #
     # @param from_id [String] The ID of the individual unblocking the relationship.
     # @param to_id [String] The ID of the blocked individual.
-    # @param scope [String] Scope for the call
+    # @param scope [String] Scope for the call.
     # 
     # Examples
     # 
@@ -92,7 +92,7 @@ module Amico
     #
     # @param from_id [String] The ID of the individual accepting the relationship.
     # @param to_id [String] The ID of the individual to be accepted.
-    # @param scope [String] Scope for the call
+    # @param scope [String] Scope for the call.
     #
     # Example
     #
@@ -110,7 +110,7 @@ module Amico
     # Count the number of individuals that someone is following.
     #
     # @param id [String] ID of the individual to retrieve following count for.
-    # @param scope [String] Scope for the call
+    # @param scope [String] Scope for the call.
     # 
     # Examples
     # 
@@ -125,7 +125,7 @@ module Amico
     # Count the number of individuals that are following someone.
     #
     # @param id [String] ID of the individual to retrieve followers count for.
-    # @param scope [String] Scope for the call
+    # @param scope [String] Scope for the call.
     #
     # Examples
     #
@@ -140,7 +140,7 @@ module Amico
     # Count the number of individuals that someone has blocked.
     #
     # @param id [String] ID of the individual to retrieve blocked count for.
-    # @param scope [String] Scope for the call
+    # @param scope [String] Scope for the call.
     # 
     # Examples
     #
@@ -155,7 +155,7 @@ module Amico
     # Count the number of individuals that have reciprocated a following relationship.
     #
     # @param id [String] ID of the individual to retrieve reciprocated following count for.
-    # @param scope [String] Scope for the call
+    # @param scope [String] Scope for the call.
     # 
     # Examples
     # 
@@ -171,7 +171,7 @@ module Amico
     # Count the number of relationships pending for an individual.
     #
     # @param id [String] ID of the individual to retrieve pending count for.
-    # @param scope [String] Scope for the call
+    # @param scope [String] Scope for the call.
     # 
     # Examples
     #
@@ -188,7 +188,7 @@ module Amico
     #
     # @param id [String] ID of the individual checking the following status.
     # @param following_id [String] ID of the individual to see if they are being followed by id.
-    # @param scope [String] Scope for the call
+    # @param scope [String] Scope for the call.
     #
     # Examples
     #
@@ -204,7 +204,7 @@ module Amico
     #
     # @param id [String] ID of the individual checking the follower status.
     # @param following_id [String] ID of the individual to see if they are following id.
-    # @param scope [String] Scope for the call
+    # @param scope [String] Scope for the call.
     #
     # Examples
     #
@@ -220,7 +220,7 @@ module Amico
     #
     # @param id [String] ID of the individual checking the blocked status.
     # @param blocked_id [String] ID of the individual to see if they are blocked by id.
-    # @param scope [String] Scope for the call
+    # @param scope [String] Scope for the call.
     #
     # Examples
     # 
@@ -236,7 +236,7 @@ module Amico
     #
     # @param from_id [String] ID of the individual checking the reciprocated relationship.
     # @param to_id [String] ID of the individual to see if they are following from_id.
-    # @param scope [String] Scope for the call
+    # @param scope [String] Scope for the call.
     #
     # Examples
     #
@@ -253,7 +253,7 @@ module Amico
     #
     # @param from_id [String] ID of the individual checking the pending relationships.
     # @param to_id [String] ID of the individual to see if they are pending a follow from from_id.
-    # @param scope [String] Scope for the call
+    # @param scope [String] Scope for the call.
     #
     # Examples
     #
@@ -269,7 +269,7 @@ module Amico
     #
     # @param id [String] ID of the individual.
     # @param options [Hash] Options to be passed for retrieving a page of followed individuals.
-    # @param scope [String] Scope for the call
+    # @param scope [String] Scope for the call.
     #
     # Examples
     #
@@ -286,7 +286,7 @@ module Amico
     #
     # @param id [String] ID of the individual.
     # @param options [Hash] Options to be passed for retrieving a page of followers.
-    # @param scope [String] Scope for the call
+    # @param scope [String] Scope for the call.
     #
     # Examples
     # 
@@ -303,7 +303,7 @@ module Amico
     #
     # @param id [String] ID of the individual.
     # @param options [Hash] Options to be passed for retrieving a page of blocked individuals.
-    # @param scope [String] Scope for the call
+    # @param scope [String] Scope for the call.
     #
     # Examples
     #
@@ -320,7 +320,7 @@ module Amico
     #
     # @param id [String] ID of the individual.
     # @param options [Hash] Options to be passed for retrieving a page of individuals that have reciprocated a follow.
-    # @param scope [String] Scope for the call
+    # @param scope [String] Scope for the call.
     #
     # Examples
     #
@@ -339,7 +339,7 @@ module Amico
     #
     # @param id [String] ID of the individual.
     # @param options [Hash] Options to be passed for retrieving a page of pending relationships.
-    # @param scope [String] Scope for the call
+    # @param scope [String] Scope for the call.
     #
     # Examples
     #
@@ -356,7 +356,7 @@ module Amico
     #
     # @param id [String] ID of the individual.
     # @param page_size [int] Page size.
-    # @param scope [String] Scope for the call
+    # @param scope [String] Scope for the call.
     #
     # Examples
     #
@@ -373,7 +373,7 @@ module Amico
     #
     # @param id [String] ID of the individual.
     # @param page_size [int] Page size (default: Amico.page_size).
-    # @param scope [String] Scope for the call
+    # @param scope [String] Scope for the call.
     #
     # Examples
     #
@@ -390,7 +390,7 @@ module Amico
     #
     # @param id [String] ID of the individual.
     # @param page_size [int] Page size (default: Amico.page_size).
-    # @param scope [String] Scope for the call
+    # @param scope [String] Scope for the call.
     #
     # Examples
     #
@@ -407,7 +407,7 @@ module Amico
     #
     # @param id [String] ID of the individual.
     # @param page_size [int] Page size (default: Amico.page_size).
-    # @param scope [String] Scope for the call
+    # @param scope [String] Scope for the call.
     #
     # Examples
     #
@@ -426,7 +426,7 @@ module Amico
     #
     # @param id [String] ID of the individual.
     # @param page_size [int] Page size (default: Amico.page_size).
-    # @param scope [String] Scope for the call
+    # @param scope [String] Scope for the call.
     #
     # Examples
     #
@@ -437,7 +437,19 @@ module Amico
     # @return the number of pages of pending relationships for an individual.
     def pending_page_count(id, page_size = Amico.page_size, scope = Amico.default_scope_key)
       total_pages("#{Amico.namespace}:#{Amico.pending_key}:#{scope}:#{id}", page_size)
-    end    
+    end
+
+    # Retrieve all of the individuals for a given id, type (e.g. following) and scope
+    #
+    # @param id [String] ID of the individual.
+    # @param type [Symbol] One of :following, :followers, :blocked, :reciprocated, :pending
+    # @param scope [String] Scope for the call.
+    def get_all(id, type, scope = Amico.default_scope_key)
+      valid_types = [:following, :followers, :blocked, :reciprocated, :pending]
+      raise "Must be one of #{valid_types.to_s}" if !valid_types.include?(type)
+      count = self.send("#{type.to_s}_count".to_sym, id, scope)
+      count > 0 ? self.send("#{type}", id, {:page_size => count}, scope) : []
+    end
 
     private
 

--- a/lib/amico/relationships.rb
+++ b/lib/amico/relationships.rb
@@ -444,7 +444,7 @@ module Amico
     # @param id [String] ID of the individual.
     # @param type [Symbol] One of :following, :followers, :blocked, :reciprocated, :pending
     # @param scope [String] Scope for the call.
-    def get_all(id, type, scope = Amico.default_scope_key)
+    def all(id, type, scope = Amico.default_scope_key)
       valid_types = [:following, :followers, :blocked, :reciprocated, :pending]
       raise "Must be one of #{valid_types.to_s}" if !valid_types.include?(type)
       count = self.send("#{type.to_s}_count".to_sym, id, scope)

--- a/lib/amico/version.rb
+++ b/lib/amico/version.rb
@@ -1,3 +1,3 @@
 module Amico
-  VERSION = '2.0.0'
+  VERSION = '2.0.1'
 end

--- a/spec/amico/relationships_spec.rb
+++ b/spec/amico/relationships_spec.rb
@@ -405,6 +405,49 @@ describe Amico::Relationships do
     end
   end
 
+  describe '#get_all' do
+    it 'should raise an exception if passing an invalid type' do
+      lambda {Amico.get_all(1, :unknown)}.should raise_error      
+    end
+
+    it 'should return the correct list when calling get_all for various types' do
+      add_reciprocal_followers(5)
+
+      [:following, :followers, :reciprocated].each do |type|
+        list = Amico.get_all(1, type)
+        # It is 29, not 30, since you cannot follow yourself
+        list.length.should be(4)
+      end
+    end
+
+    it 'should return the correct list when calling get_all for a pending relationship' do
+      Amico.pending_follow = true
+      add_reciprocal_followers(5)
+
+      [:following, :followers, :reciprocated].each do |type|
+        list = Amico.get_all(1, type)
+        list.length.should be(0)
+      end
+
+      pending_list = Amico.get_all(1, :pending)
+      pending_list.length.should be(4)
+
+      Amico.pending_follow = false
+    end
+
+    it 'should return the correct list when calling get_all for a blocked relationship' do
+      add_reciprocal_followers(5, true)
+
+      [:following, :followers, :reciprocated].each do |type|
+        list = Amico.get_all(1, type)
+        list.length.should be(0)
+      end
+
+      blocked_list = Amico.get_all(1, :blocked)
+      blocked_list.length.should be(4)
+    end
+  end
+
   private
 
   def add_reciprocal_followers(count = 26, block_relationship = false)

--- a/spec/amico/relationships_spec.rb
+++ b/spec/amico/relationships_spec.rb
@@ -405,45 +405,45 @@ describe Amico::Relationships do
     end
   end
 
-  describe '#get_all' do
+  describe '#all' do
     it 'should raise an exception if passing an invalid type' do
-      lambda {Amico.get_all(1, :unknown)}.should raise_error      
+      lambda {Amico.all(1, :unknown)}.should raise_error      
     end
 
-    it 'should return the correct list when calling get_all for various types' do
+    it 'should return the correct list when calling all for various types' do
       add_reciprocal_followers(5)
 
       [:following, :followers, :reciprocated].each do |type|
-        list = Amico.get_all(1, type)
+        list = Amico.all(1, type)
         # It is 29, not 30, since you cannot follow yourself
         list.length.should be(4)
       end
     end
 
-    it 'should return the correct list when calling get_all for a pending relationship' do
+    it 'should return the correct list when calling all for a pending relationship' do
       Amico.pending_follow = true
       add_reciprocal_followers(5)
 
       [:following, :followers, :reciprocated].each do |type|
-        list = Amico.get_all(1, type)
+        list = Amico.all(1, type)
         list.length.should be(0)
       end
 
-      pending_list = Amico.get_all(1, :pending)
+      pending_list = Amico.all(1, :pending)
       pending_list.length.should be(4)
 
       Amico.pending_follow = false
     end
 
-    it 'should return the correct list when calling get_all for a blocked relationship' do
+    it 'should return the correct list when calling all for a blocked relationship' do
       add_reciprocal_followers(5, true)
 
       [:following, :followers, :reciprocated].each do |type|
-        list = Amico.get_all(1, type)
+        list = Amico.all(1, type)
         list.length.should be(0)
       end
 
-      blocked_list = Amico.get_all(1, :blocked)
+      blocked_list = Amico.all(1, :blocked)
       blocked_list.length.should be(4)
     end
   end


### PR DESCRIPTION
- Added `Amico.all(id, type, scope)` to retrieve all of the individuals for a given id, type (e.g. following) and scope. Thanks to @mettadore for the initial code and inspiration.
