### PR TITLE
Clear all relationships for a given key

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@ Amico.configure do |configuration|
   configuration.following_key = 'following'
   configuration.followers_key = 'followers'
   configuration.blocked_key = 'blocked'
+  configuration.blocked_by_key = 'blocked_by'
   configuration.reciprocated_key = 'reciprocated'
   configuration.pending_key = 'pending'
+  configuration.pending_with_key = 'pending_with'
   configuration.default_scope_key = 'default'
   configuration.pending_follow = false
   configuration.page_size = 25
@@ -46,8 +48,10 @@ Amico.configure do |configuration|
   configuration.following_key = 'following'
   configuration.followers_key = 'followers'
   configuration.blocked_key = 'blocked'
+  configuration.blocked_by_key = 'blocked_by'
   configuration.reciprocated_key = 'reciprocated'
   configuration.pending_key = 'pending'
+  configuration.pending_with_key = 'pending_with'
   configuration.default_scope_key = 'default'
   configuration.pending_follow = false
   configuration.page_size = 25
@@ -98,10 +102,16 @@ Amico.following?(11, 1)
 Amico.blocked?(1, 11)
  => true
 
+Amico.blocked_by?(11, 1)
+ => true
+
 Amico.unblock(1, 11)
  => true
 
 Amico.blocked?(1, 11)
+ => false
+
+Amico.blocked_by?(11, 1)
  => false
 
 Amico.follow(11, 1)
@@ -129,8 +139,10 @@ Amico.configure do |configuration|
   configuration.following_key = 'following'
   configuration.followers_key = 'followers'
   configuration.blocked_key = 'blocked'
+  configuration.blocked_by_key = 'blocked_by'
   configuration.reciprocated_key = 'reciprocated'
   configuration.pending_key = 'pending'
+  configuration.pending_with_key = 'pending_with'
   configuration.default_scope_key = 'default'
   configuration.pending_follow = true
   configuration.page_size = 25
@@ -145,7 +157,13 @@ Amico.follow(11, 1)
 Amico.pending?(1, 11)
  => true
 
+Amico.pending_with?(11, 1)
+ => true
+
 Amico.pending?(11, 1)
+ => true
+
+Amico.pending_with?(1, 11)
  => true
 
 Amico.accept(1, 11)
@@ -154,7 +172,13 @@ Amico.accept(1, 11)
 Amico.pending?(1, 11)
  => false
 
+Amico.pending_with?(11, 1)
+ => false
+
 Amico.pending?(11, 1)
+ => true
+
+Amico.pending_with?(1, 11)
  => true
 
 Amico.following?(1, 11)
@@ -175,7 +199,13 @@ Amico.accept(11, 1)
 Amico.pending?(1, 11)
  => false
 
+Amico.pending_with?(11, 1)
+ => false
+
 Amico.pending?(11, 1)
+ => false
+
+Amico.pending_with?(1, 11)
  => false
 
 Amico.following?(1, 11)
@@ -205,8 +235,10 @@ Amico.configure do |configuration|
   configuration.following_key = 'following'
   configuration.followers_key = 'followers'
   configuration.blocked_key = 'blocked'
+  configuration.blocked_by_key = 'blocked_by'
   configuration.reciprocated_key = 'reciprocated'
   configuration.pending_key = 'pending'
+  configuration.pending_with_key = 'pending_with'
   configuration.default_scope_key = 'default'
   configuration.pending_follow = false
   configuration.page_size = 25
@@ -293,8 +325,10 @@ Amico.configure do |configuration|
   configuration.following_key = 'following'
   configuration.followers_key = 'followers'
   configuration.blocked_key = 'blocked'
+  configuration.blocked_by_key = 'blocked_by'
   configuration.reciprocated_key = 'reciprocated'
   configuration.pending_key = 'pending'
+  configuration.pending_with_key = 'pending_with'
   configuration.default_scope_key = 'default'
   configuration.pending_follow = true
   configuration.page_size = 25
@@ -365,8 +399,10 @@ Amico.configure do |configuration|
   configuration.following_key = 'following'
   configuration.followers_key = 'followers'
   configuration.blocked_key = 'blocked'
+  configuration.blocked_by_key = 'blocked_by'
   configuration.reciprocated_key = 'reciprocated'
   configuration.pending_key = 'pending'
+  configuration.pending_with_key = 'pending_with'
   configuration.default_scope_key = 'user'
   configuration.pending_follow = false
   configuration.page_size = 25
@@ -411,6 +447,25 @@ Amico.all(1, :following)
 
 `type` can be one of :following, :followers, :blocked, :reciprocated, :pending. Use this with caution
 as there may potentially be a large number of items that could be returned from this call.
+
+You can clear all relationships that have been set for an ID by calling `clear(id, scope)`. You may wish to do this if you allow records to be deleted and you wish to prevent orphaned IDs and inaccurate follower/following counts. Note that this clears *all* relationships in either direction - including blocked and pending. An example:
+
+```ruby
+Amico.follow(11, 1)
+ => nil
+Amico.block(12, 1)
+ => nil
+Amico.following(11)
+ => ["1"]
+Amico.blocked(12)
+ => ["1"]
+Amico.clear(1)
+ => nil
+Amico.following(11)
+ => []
+Amico.blocked(12)
+ => []
+```
 
 ## Method Summary
 

--- a/README.md
+++ b/README.md
@@ -438,10 +438,14 @@ following(id, page_options = default_paging_options, scope = Amico.default_scope
 followers(id, page_options = default_paging_options, scope = Amico.default_scope_key)
 # Retrieve a page of blocked individuals for a given ID.
 blocked(id, page_options = default_paging_options, scope = Amico.default_scope_key)
+# Retrieve a page of individuals who have blocked a given ID.
+blocked_by(id, page_options = default_paging_options, scope = Amico.default_scope_key)
 # Retrieve a page of individuals that have reciprocated a follow for a given ID.
 reciprocated(id, page_options = default_paging_options, scope = Amico.default_scope_key)
 # Retrieve a page of pending relationships for a given ID.
 pending(id, page_options = default_paging_options, scope = Amico.default_scope_key)
+# Retrieve a page of individuals that are waiting to approve the given ID.
+pending_with(id, page_options = default_paging_options, scope = Amico.default_scope_key)
 
 # Retrieve all of the individuals for a given id, type (e.g. following) and scope.
 all(id, type, scope = Amico.default_scope_key)
@@ -454,10 +458,14 @@ following_count(id, scope = Amico.default_scope_key)
 followers_count(id, scope = Amico.default_scope_key)
 # Count the number of individuals that someone has blocked.
 blocked_count(id, scope = Amico.default_scope_key)
+# Count the number of individuals blocking another.
+blocked_by_count(id, scope = Amico.default_scope_key)
 # Count the number of individuals that have reciprocated a following relationship.
 reciprocated_count(id, scope = Amico.default_scope_key)
 # Count the number of relationships pending for an individual.
 pending_count(id, scope = Amico.default_scope_key)
+# Count the number of relationships an individual has pending with another.
+pending_with_count(id, scope = Amico.default_scope_key)
 
 # Count the number of pages of following relationships for an individual.
 following_page_count(id, page_size = Amico.page_size, scope = Amico.default_scope_key)
@@ -465,10 +473,14 @@ following_page_count(id, page_size = Amico.page_size, scope = Amico.default_scop
 followers_page_count(id, page_size = Amico.page_size, scope = Amico.default_scope_key)
 # Count the number of pages of blocked relationships for an individual.
 blocked_page_count(id, page_size = Amico.page_size, scope = Amico.default_scope_key)
+# Count the number of pages of blocked_by relationships for an individual.
+blocked_by_page_count(id, page_size = Amico.page_size, scope = Amico.default_scope_key)
 # Count the number of pages of reciprocated relationships for an individual.
 reciprocated_page_count(id, page_size = Amico.page_size, scope = Amico.default_scope_key)
 # Count the number of pages of pending relationships for an individual.
 pending_page_count(id, page_size = Amico.page_size, scope = Amico.default_scope_key)
+# Count the number of pages of individuals waiting to approve another individual.
+pending_with_page_count(id, page_size = Amico.page_size, scope = Amico.default_scope_key)
 
 # Checks
 
@@ -478,10 +490,14 @@ following?(id, following_id, scope = Amico.default_scope_key)
 follower?(id, follower_id, scope = Amico.default_scope_key)
 # Check to see if one individual has blocked another individual.
 blocked?(id, blocked_id, scope = Amico.default_scope_key)
+# Check to see if one individual is blocked by another individual.
+blocked_by?(id, blocked_id, scope = Amico.default_scope_key)
 # Check to see if one individual has reciprocated in following another individual.
 reciprocated?(from_id, to_id, scope = Amico.default_scope_key)
 # Check to see if one individual has a pending relationship in following another individual.
 pending?(from_id, to_id, scope = Amico.default_scope_key)
+# Check to see if one individual has a pending relationship with another.
+pending_with?(from_id, to_id, scope = Amico.default_scope_key)
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -427,6 +427,8 @@ block(from_id, to_id, scope = Amico.default_scope_key)
 unblock(from_id, to_id, scope = Amico.default_scope_key)
 # Accept a relationship that is pending between two IDs.
 accept(from_id, to_id, scope = Amico.default_scope_key)
+# Clear all relationships (in either direction) for a given ID.
+clear(id, scope = Amico.default_scope_key)
 
 # Retrieval
 

--- a/lib/amico/configuration.rb
+++ b/lib/amico/configuration.rb
@@ -16,11 +16,17 @@ module Amico
     # Key used in Redis for tracking who an individual blocks.
     attr_writer :blocked_key
 
+    # Key used in Redis for tracking who has blocked an individual.
+    attr_writer :blocked_by_key
+
     # Key used in Redis for tracking who has reciprocated a follow for an individual.
     attr_writer :reciprocated_key
 
     # Key used in Redis for tracking pending follow relationships for an individual.
     attr_writer :pending_key
+
+    # Key used in Redis for tracking who an individual is awaiting approval from.
+    attr_writer :pending_with_key
 
     # Key used to indicate whether or not a follow should be pending or not.
     attr_writer :pending_follow
@@ -79,6 +85,13 @@ module Amico
       @blocked_key ||= 'blocked'
     end
 
+    # Key used in Redis for tracking who has blocked an individual.
+    # 
+    # @return the key used in Redis for tracking who has blocked an individual or the default of 'blocked_by' if not set.
+    def blocked_by_key
+      @blocked_by_key ||= 'blocked_by'
+    end
+
     # Key used in Redis for tracking who has reciprocated a follow for an individual.
     #
     # @return the key used in Redis for tracking who has reciprocated a follow for an individual or the default of 'reciprocated' if not set.
@@ -91,6 +104,13 @@ module Amico
     # @return the key used in Redis for tracking pending follow relationships for an individual.
     def pending_key
       @pending_key ||= 'pending'
+    end
+
+    # Key used in Redis for tracking who an individual is awaiting approval from.
+    #
+    # @return the key used in Redis for tracking who an individual is awaiting approval from or the default of 'pending_with' if not set.
+    def pending_with_key
+      @pending_with_key ||= 'pending_with'
     end
 
     # Default key used in Redis for tracking scope for the given relationship calls.

--- a/lib/amico/configuration.rb
+++ b/lib/amico/configuration.rb
@@ -47,8 +47,10 @@ module Amico
     #     configuration.following_key = 'following'
     #     configuration.followers_key = 'followers'
     #     configuration.blocked_key = 'blocked'
+    #     configuration.blocked_by_key = 'blocked_by'
     #     configuration.reciprocated_key = 'reciprocated'
     #     configuration.pending_key = 'pending'
+    #     configuration.pending_with_key = 'pending_with'
     #     configuration.default_scope_key = 'default'
     #     configuration.pending_follow = false
     #     configuration.page_size = 25

--- a/lib/amico/relationships.rb
+++ b/lib/amico/relationships.rb
@@ -474,11 +474,10 @@ module Amico
 	# Retrieve all of the individuals for a given id, type (e.g. following) and scope
 	#
 	# @param id [String] ID of the individual.
-	# @param type [Symbol] One of :following, :followers, :blocked, :reciprocated, :pending.
+	# @param type [Symbol] One of :following, :followers, :reciprocated, :blocked, :blocked_by, :pending, :pending_with.
 	# @param scope [String] Scope for the call.
 	def all(id, type, scope = Amico.default_scope_key)
-	  valid_types = [:following, :followers, :blocked, :reciprocated, :pending]
-	  raise "Must be one of #{valid_types.to_s}" if !valid_types.include?(type)
+    validate_relationship_type(type)
 	  count = self.send("#{type.to_s}_count".to_sym, id, scope)
 	  count > 0 ? self.send("#{type}", id, {:page_size => count}, scope) : []
 	end
@@ -486,27 +485,40 @@ module Amico
   # Retrieve a count of all of a given type of relationship for the specified id.
   #
   # @param id [String] ID of the individual.
-  # @param type [Symbol] One of :following, :followers, :blocked, :reciprocated, :pending.
+	# @param type [Symbol] One of :following, :followers, :reciprocated, :blocked, :blocked_by, :pending, :pending_with.
   # @param scope [String] Scope for the call.
   #
   # @return Count of all of a given type of relationship for the specified id.
 	def count(id, type, scope = Amico.default_scope_key)
+    validate_relationship_type(type)
     self.send("#{type.to_s}_count".to_sym, id, scope)
 	end
 
   # Retrieve a page count of a given type of relationship for the specified id.
   #
   # @param id [String] ID of the individual.
-  # @param type [Symbol] One of :following, :followers, :blocked, :reciprocated, :pending.
+	# @param type [Symbol] One of :following, :followers, :reciprocated, :blocked, :blocked_by, :pending, :pending_with.
   # @param page_size [int] Page size (default: Amico.page_size).
   # @param scope [String] Scope for the call.
   #
   # @return Page count of a given type of relationship for the specified id.
   def page_count(id, type, page_size = Amico.page_size, scope = Amico.default_scope_key)
+    validate_relationship_type(type)
     self.send("#{type.to_s}_page_count".to_sym, id, page_size, scope)
   end
 
 	private
+
+  # Valid relationtionships that can be used in #all, #count, #page_count, etc...
+  VALID_RELATIONSHIPS = [:following, :followers, :reciprocated, :blocked, :blocked_by, :pending, :pending_with]
+
+  # Ensure that a relationship type is valid.
+  # 
+  # @param type [Symbol] One of :following, :followers, :reciprocated, :blocked, :blocked_by, :pending, :pending_with.
+  # @raise [StandardError] if the type is not included in VALID_RELATIONSHIPS
+  def validate_relationship_type(type)
+    raise "Must be one of #{VALID_RELATIONSHIPS.to_s}" if !VALID_RELATIONSHIPS.include?(type)
+  end
 
 	# Default paging options.
 	#

--- a/lib/amico/relationships.rb
+++ b/lib/amico/relationships.rb
@@ -231,6 +231,22 @@ module Amico
 	  Amico.redis.zcard("#{Amico.namespace}:#{Amico.pending_key}:#{scope}:#{id}")
 	end
 
+	# Count the number of relationships an individual has pending with another.
+	#
+	# @param id [String] ID of the individual to retrieve pending count for.
+	# @param scope [String] Scope for the call.
+	# 
+	# Examples
+	#
+	#   Amico.follow(1, 11)
+	#   Amico.follow(1, 12)
+	#   Amico.pending_count(1) # 2
+	#
+	# @return the count of the number of relationships an individual has pending with another.
+	def pending_with_count(id, scope = Amico.default_scope_key)
+	  Amico.redis.zcard("#{Amico.namespace}:#{Amico.pending_with_key}:#{scope}:#{id}")
+	end
+
 	# Check to see if one individual is following another individual.
 	#
 	# @param id [String] ID of the individual checking the following status.
@@ -328,6 +344,22 @@ module Amico
 	  !Amico.redis.zscore("#{Amico.namespace}:#{Amico.pending_key}:#{scope}:#{to_id}", from_id).nil?
 	end
 
+	# Check to see if one individual has a pending relationship with another.
+	#
+	# @param from_id [String] ID of the individual checking the pending relationships.
+	# @param to_id [String] ID of the individual to see if they are pending an approval from from_id.
+	# @param scope [String] Scope for the call.
+	#
+	# Examples
+	#
+	#   Amico.follow(1, 11)
+	#   Amico.pending_with?(11, 1) # true
+	#
+	# @return true if the relationship is pending, false otherwise
+	def pending_with?(from_id, to_id, scope = Amico.default_scope_key)
+	  !Amico.redis.zscore("#{Amico.namespace}:#{Amico.pending_with_key}:#{scope}:#{to_id}", from_id).nil?
+	end
+
 	# Retrieve a page of followed individuals for a given ID.
 	#
 	# @param id [String] ID of the individual.
@@ -423,13 +455,30 @@ module Amico
 	#
 	# Examples
 	#
-	#   Amico.follow(1, 11)
-	#   Amico.follow(2, 11)
+	#   Amico.follow(11, 1)
+	#   Amico.follow(12, 1)
 	#   Amico.pending(1, :page => 1)
 	#
 	# @return a page of pending relationships for a given ID.
 	def pending(id, page_options = default_paging_options, scope = Amico.default_scope_key)
 	  members("#{Amico.namespace}:#{Amico.pending_key}:#{scope}:#{id}", page_options)
+	end
+
+	# Retrieve a page of individuals that are waiting to approve the given ID.
+	#
+	# @param id [String] ID of the individual.
+	# @param page_options [Hash] Options to be passed for retrieving a page of pending relationships.
+	# @param scope [String] Scope for the call.
+	#
+	# Examples
+	#
+	#   Amico.follow(1, 11)
+	#   Amico.follow(1, 12)
+	#   Amico.pending_with(1, :page => 1)
+	#
+	# @return a page of individuals that are waiting to approve the given ID.
+	def pending_with(id, page_options = default_paging_options, scope = Amico.default_scope_key)
+	  members("#{Amico.namespace}:#{Amico.pending_with_key}:#{scope}:#{id}", page_options)
 	end
 
 	# Count the number of pages of following relationships for an individual.
@@ -534,6 +583,23 @@ module Amico
 	# @return the number of pages of pending relationships for an individual.
 	def pending_page_count(id, page_size = Amico.page_size, scope = Amico.default_scope_key)
 	  total_pages("#{Amico.namespace}:#{Amico.pending_key}:#{scope}:#{id}", page_size)
+	end
+
+	# Count the number of pages of individuals waiting to approve another individual.
+	#
+	# @param id [String] ID of the individual.
+	# @param page_size [int] Page size (default: Amico.page_size).
+	# @param scope [String] Scope for the call.
+	#
+	# Examples
+	#
+	#   Amico.follow(1, 11)
+	#   Amico.follow(1, 12)
+	#   Amico.pending_with_page_count(1) # 1
+	#    
+	# @return the number of pages of individuals waiting to approve another individual.
+	def pending_with_page_count(id, page_size = Amico.page_size, scope = Amico.default_scope_key)
+	  total_pages("#{Amico.namespace}:#{Amico.pending_with_key}:#{scope}:#{id}", page_size)
 	end
 
 	# Retrieve all of the individuals for a given id, type (e.g. following) and scope

--- a/lib/amico/relationships.rb
+++ b/lib/amico/relationships.rb
@@ -184,6 +184,21 @@ module Amico
 	  Amico.redis.zcard("#{Amico.namespace}:#{Amico.blocked_key}:#{scope}:#{id}")
 	end
 
+	# Count the number of individuals blocking another.
+	#
+	# @param id [String] ID of the individual to retrieve blocked_by count for.
+	# @param scope [String] Scope for the call.
+	# 
+	# Examples
+	#
+	#   Amico.block(1, 11)
+	#   Amico.blocked_by_count(11)
+	#
+	# @return the count of the number of individuals blocking someone.
+	def blocked_by_count(id, scope = Amico.default_scope_key)
+	  Amico.redis.zcard("#{Amico.namespace}:#{Amico.blocked_by_key}:#{scope}:#{id}")
+	end
+
 	# Count the number of individuals that have reciprocated a following relationship.
 	#
 	# @param id [String] ID of the individual to retrieve reciprocated following count for.
@@ -262,6 +277,22 @@ module Amico
 	# @return true if id has blocked blocked_id, false otherwise
 	def blocked?(id, blocked_id, scope = Amico.default_scope_key)
 	  !Amico.redis.zscore("#{Amico.namespace}:#{Amico.blocked_key}:#{scope}:#{id}", blocked_id).nil?
+	end
+
+	# Check to see if one individual is blocked by another individual.
+	#
+	# @param id [String] ID of the individual checking the blocked by status.
+	# @param blocked_id [String] ID of the individual to see if they have blocked id.
+	# @param scope [String] Scope for the call.
+	#
+	# Examples
+	# 
+	#   Amico.block(1, 11)
+	#   Amico.blocked_by?(11, 1)
+	#
+	# @return true if id is blocked by blocked_by_id, false otherwise
+	def blocked_by?(id, blocked_by_id, scope = Amico.default_scope_key)
+	  !Amico.redis.zscore("#{Amico.namespace}:#{Amico.blocked_by_key}:#{scope}:#{id}", blocked_by_id).nil?
 	end
 
 	# Check to see if one individual has reciprocated in following another individual.
@@ -346,6 +377,23 @@ module Amico
 	# @return a page of blocked individuals for a given ID.
 	def blocked(id, page_options = default_paging_options, scope = Amico.default_scope_key)
 	  members("#{Amico.namespace}:#{Amico.blocked_key}:#{scope}:#{id}", page_options)
+	end
+
+	# Retrieve a page of individuals who have blocked a given ID.
+	#
+	# @param id [String] ID of the individual.
+	# @param page_options [Hash] Options to be passed for retrieving a page of blocking individuals.
+	# @param scope [String] Scope for the call.
+	#
+	# Examples
+	#
+	#   Amico.block(11, 1)
+	#   Amico.block(12, 1)
+	#   Amico.blocked_by(1, :page => 1)
+	#
+	# @return a page of individuals who have blocked a given ID.
+	def blocked_by(id, page_options = default_paging_options, scope = Amico.default_scope_key)
+	  members("#{Amico.namespace}:#{Amico.blocked_by_key}:#{scope}:#{id}", page_options)
 	end
 
 	# Retrieve a page of individuals that have reciprocated a follow for a given ID.
@@ -433,6 +481,23 @@ module Amico
 	# @return the number of pages of blocked relationships for an individual.
 	def blocked_page_count(id, page_size = Amico.page_size, scope = Amico.default_scope_key)
 	  total_pages("#{Amico.namespace}:#{Amico.blocked_key}:#{scope}:#{id}", page_size)
+	end
+
+	# Count the number of pages of blocked_by relationships for an individual.
+	#
+	# @param id [String] ID of the individual.
+	# @param page_size [int] Page size (default: Amico.page_size).
+	# @param scope [String] Scope for the call.
+	#
+	# Examples
+	#
+	#   Amico.block(11, 1)
+	#   Amico.block(12, 1)
+	#   Amico.blocked_by_page_count(1)
+	#    
+	# @return the number of pages of blocked_by relationships for an individual.
+	def blocked_by_page_count(id, page_size = Amico.page_size, scope = Amico.default_scope_key)
+	  total_pages("#{Amico.namespace}:#{Amico.blocked_by_key}:#{scope}:#{id}", page_size)
 	end
 
 	# Count the number of pages of reciprocated relationships for an individual.

--- a/spec/amico/configuration_spec.rb
+++ b/spec/amico/configuration_spec.rb
@@ -8,8 +8,10 @@ describe Amico::Configuration do
         configuration.following_key.should eql('following')
         configuration.followers_key.should eql('followers')
         configuration.blocked_key.should eql('blocked')
+        configuration.blocked_by_key.should eql('blocked_by')
         configuration.reciprocated_key.should eql('reciprocated')
         configuration.pending_key.should eql('pending')
+        configuration.pending_with_key.should eql('pending_with')
         configuration.default_scope_key.should eql('default')
         configuration.pending_follow.should be_false
         configuration.page_size.should be(25)

--- a/spec/amico/relationships_spec.rb
+++ b/spec/amico/relationships_spec.rb
@@ -344,10 +344,12 @@ describe Amico::Relationships do
       it 'should remove the pending relationship and add to following and followers if #accept is called' do
         Amico.follow(1, 11)
         Amico.pending?(1, 11).should be_true
+        Amico.pending_with?(11, 1).should be_true
 
         Amico.accept(1, 11)
 
         Amico.pending?(1, 11).should be_false
+        Amico.pending_with?(11, 1).should be_false
         Amico.following?(1, 11).should be_true
         Amico.following?(11, 1).should be_false
         Amico.follower?(11, 1).should be_true
@@ -385,8 +387,10 @@ describe Amico::Relationships do
       it 'should remove the pending relationship if you block someone' do
         Amico.follow(11, 1)
         Amico.pending?(11, 1).should be_true
+        Amico.pending_with?(1, 11).should be_true
         Amico.block(1, 11)
         Amico.pending?(11, 1).should be_false
+        Amico.pending_with?(1, 11).should be_false
         Amico.blocked?(1, 11).should be_true
       end
     end
@@ -408,6 +412,23 @@ describe Amico::Relationships do
       end
     end
 
+    describe '#pending_with' do
+      it 'should return the correct list' do
+        Amico.follow(1, 11)
+        Amico.follow(11, 1)
+        Amico.pending_with(1).should eql(["11"])
+        Amico.pending_with(11).should eql(["1"])
+      end
+
+      it 'should page correctly' do
+        add_reciprocal_followers
+
+        Amico.pending_with(1, :page => 1, :page_size => 5).size.should be(5)
+        Amico.pending_with(1, :page => 1, :page_size => 10).size.should be(10)
+        Amico.pending_with(1, :page => 1, :page_size => 26).size.should be(25)
+      end
+    end
+
     describe '#pending_count' do
       it 'should return the correct count' do
         Amico.follow(1, 11)
@@ -419,6 +440,17 @@ describe Amico::Relationships do
       end
     end
 
+    describe '#pending_with_count' do
+      it 'should return the correct count' do
+        Amico.follow(1, 11)
+        Amico.follow(11, 1)
+        Amico.follow(1, 12)
+        Amico.follow(12, 1)
+        Amico.follow(1, 13)
+        Amico.pending_with_count(1).should be(3)
+      end
+    end
+
     describe '#pending_page_count' do
       it 'should return the correct count' do
         add_reciprocal_followers
@@ -426,6 +458,16 @@ describe Amico::Relationships do
         Amico.pending_page_count(1).should be(1)
         Amico.pending_page_count(1, 10).should be(3)
         Amico.pending_page_count(1, 5).should be(5)
+      end
+    end
+
+    describe '#pending_with_page_count' do
+      it 'should return the correct count' do
+        add_reciprocal_followers
+
+        Amico.pending_with_page_count(1).should be(1)
+        Amico.pending_with_page_count(1, 10).should be(3)
+        Amico.pending_with_page_count(1, 5).should be(5)
       end
     end
   end

--- a/spec/amico/relationships_spec.rb
+++ b/spec/amico/relationships_spec.rb
@@ -120,6 +120,13 @@ describe Amico::Relationships do
     end
   end
 
+  describe '#blocked_by?' do
+    it 'should return that someone is blocking you' do
+      Amico.block(1, 11)
+      Amico.blocked_by?(11, 1).should be_true
+    end
+  end
+
   describe '#reciprocated?' do
     it 'should return true if both individuals are following each other' do
       Amico.follow(1, 11)
@@ -184,6 +191,15 @@ describe Amico::Relationships do
     end
   end
 
+  describe '#blocked_by' do
+    it 'should return the correct list' do
+      Amico.block(11, 1)
+      Amico.block(12, 1)
+      Amico.blocked_by(1).should eql(["12", "11"])
+      Amico.blocked_by(1, :page => 5).should eql(["12", "11"])
+    end
+  end
+
   describe '#reciprocated' do
     it 'should return the correct list' do
       Amico.follow(1, 11)
@@ -219,6 +235,13 @@ describe Amico::Relationships do
     it 'should return the correct count' do
       Amico.block(1, 11)
       Amico.blocked_count(1).should be(1)
+    end
+  end
+
+  describe '#blocked_by_count' do
+    it 'should return the correct count' do
+      Amico.block(1, 11)
+      Amico.blocked_by_count(11).should be(1)
     end
   end
 
@@ -260,6 +283,16 @@ describe Amico::Relationships do
       Amico.blocked_page_count(1).should be(1)
       Amico.blocked_page_count(1, 10).should be(3)
       Amico.blocked_page_count(1, 5).should be(5)
+    end
+  end
+
+  describe '#blocked_by_page_count' do
+    it 'should return the correct count' do
+      add_reciprocal_followers(26, true)
+
+      Amico.blocked_by_page_count(1).should be(1)
+      Amico.blocked_by_page_count(1, 10).should be(3)
+      Amico.blocked_by_page_count(1, 5).should be(5)
     end
   end
 
@@ -452,6 +485,9 @@ describe Amico::Relationships do
 
       blocked_list = Amico.all(1, :blocked)
       blocked_list.length.should be(4)
+
+      blocked_by_list = Amico.all(1, :blocked_by)
+      blocked_by_list.length.should be(4)
     end
   end
 
@@ -501,6 +537,7 @@ describe Amico::Relationships do
       add_reciprocal_followers(5, true)
 
       Amico.count(1, :blocked).should eql(4)
+      Amico.count(1, :blocked_by).should eql(4)
 
       Amico.redis.flushdb
       Amico.pending_follow = true
@@ -522,6 +559,7 @@ describe Amico::Relationships do
       add_reciprocal_followers(5, true)
 
       Amico.page_count(1, :blocked).should eql(1)
+      Amico.page_count(1, :blocked_by).should eql(1)
 
       Amico.redis.flushdb
       Amico.pending_follow = true
@@ -564,8 +602,10 @@ describe Amico::Relationships do
     it 'should clear blocked/blocked_by relationships' do
       Amico.block(1, 11)
       Amico.blocked_count(1).should be(1)
+      Amico.blocked_by_count(11).should be(1)
       Amico.clear(11)
       Amico.blocked_count(1).should be(0)
+      Amico.blocked_by_count(11).should be(0)
     end
   end
 

--- a/spec/amico/relationships_spec.rb
+++ b/spec/amico/relationships_spec.rb
@@ -531,6 +531,45 @@ describe Amico::Relationships do
     end
   end
 
+
+
+  describe '#clear' do
+    it 'should remove follower/following relationships' do
+      Amico.follow(1, 11)
+      Amico.follow(11, 1)
+      
+      Amico.following_count(1).should be(1)
+      Amico.followers_count(1).should be(1)
+      Amico.reciprocated_count(1).should be(1)
+      Amico.following_count(11).should be(1)
+      Amico.followers_count(11).should be(1)
+      Amico.reciprocated_count(11).should be(1)
+      
+      Amico.clear(1)
+      
+      Amico.following_count(1).should be(0)
+      Amico.followers_count(1).should be(0)
+      Amico.reciprocated_count(1).should be(0)
+      Amico.following_count(11).should be(0)
+      Amico.followers_count(11).should be(0)
+      Amico.reciprocated_count(11).should be(0)
+    end
+    it 'should clear pending/pending_with relationships' do
+      Amico.pending_follow = true
+      Amico.follow(1, 11)
+      Amico.pending_count(11).should be(1)
+      Amico.clear(1)
+      Amico.pending_count(11).should be(0)
+    end
+    it 'should clear blocked/blocked_by relationships' do
+      Amico.block(1, 11)
+      Amico.blocked_count(1).should be(1)
+      Amico.clear(11)
+      Amico.blocked_count(1).should be(0)
+    end
+  end
+
+
   private
 
   def add_reciprocal_followers(count = 26, block_relationship = false)

--- a/spec/amico/relationships_spec.rb
+++ b/spec/amico/relationships_spec.rb
@@ -48,6 +48,7 @@ describe Amico::Relationships do
 
       Amico.redis.zcard("#{Amico.namespace}:#{Amico.following_key}:#{Amico.default_scope_key}:11").should be(0)
       Amico.redis.zcard("#{Amico.namespace}:#{Amico.blocked_key}:#{Amico.default_scope_key}:1").should be(1)
+      Amico.redis.zcard("#{Amico.namespace}:#{Amico.blocked_by_key}:#{Amico.default_scope_key}:11").should be(1)
       Amico.redis.zcard("#{Amico.namespace}:#{Amico.reciprocated_key}:#{Amico.default_scope_key}:1").should be(0)
       Amico.redis.zcard("#{Amico.namespace}:#{Amico.reciprocated_key}:#{Amico.default_scope_key}:11").should be(0)
     end
@@ -57,6 +58,7 @@ describe Amico::Relationships do
 
       Amico.redis.zcard("#{Amico.namespace}:#{Amico.following_key}:#{Amico.default_scope_key}:11").should be(0)
       Amico.redis.zcard("#{Amico.namespace}:#{Amico.blocked_key}:#{Amico.default_scope_key}:1").should be(1)
+      Amico.redis.zcard("#{Amico.namespace}:#{Amico.blocked_by_key}:#{Amico.default_scope_key}:11").should be(1)
     end
 
     it 'should not allow someone you have blocked to follow you' do
@@ -81,8 +83,10 @@ describe Amico::Relationships do
     it 'should allow you to unblock someone you have blocked' do
       Amico.block(1, 11)
       Amico.blocked?(1, 11).should be_true
+      Amico.redis.zcard("#{Amico.namespace}:#{Amico.blocked_by_key}:#{Amico.default_scope_key}:11").should be(1)
       Amico.unblock(1, 11)
       Amico.blocked?(1, 11).should be_false
+      Amico.redis.zcard("#{Amico.namespace}:#{Amico.blocked_by_key}:#{Amico.default_scope_key}:11").should be(0)
     end
   end
 
@@ -285,6 +289,7 @@ describe Amico::Relationships do
         Amico.redis.zcard("#{Amico.namespace}:#{Amico.following_key}:#{Amico.default_scope_key}:1").should be(0)
         Amico.redis.zcard("#{Amico.namespace}:#{Amico.followers_key}:#{Amico.default_scope_key}:11").should be(0)
         Amico.redis.zcard("#{Amico.namespace}:#{Amico.pending_key}:#{Amico.default_scope_key}:11").should be(1)
+        Amico.redis.zcard("#{Amico.namespace}:#{Amico.pending_with_key}:#{Amico.default_scope_key}:1").should be(1)
       end
 
       it 'should remove the pending relationship if you have a pending follow, but you unfollow' do
@@ -293,12 +298,14 @@ describe Amico::Relationships do
         Amico.redis.zcard("#{Amico.namespace}:#{Amico.following_key}:#{Amico.default_scope_key}:1").should be(0)
         Amico.redis.zcard("#{Amico.namespace}:#{Amico.followers_key}:#{Amico.default_scope_key}:11").should be(0)
         Amico.redis.zcard("#{Amico.namespace}:#{Amico.pending_key}:#{Amico.default_scope_key}:11").should be(1)
+        Amico.redis.zcard("#{Amico.namespace}:#{Amico.pending_with_key}:#{Amico.default_scope_key}:1").should be(1)
 
         Amico.unfollow(1, 11)
 
         Amico.redis.zcard("#{Amico.namespace}:#{Amico.following_key}:#{Amico.default_scope_key}:1").should be(0)
         Amico.redis.zcard("#{Amico.namespace}:#{Amico.followers_key}:#{Amico.default_scope_key}:11").should be(0)
         Amico.redis.zcard("#{Amico.namespace}:#{Amico.pending_key}:#{Amico.default_scope_key}:11").should be(0)
+        Amico.redis.zcard("#{Amico.namespace}:#{Amico.pending_with_key}:#{Amico.default_scope_key}:1").should be(0)
       end
 
       it 'should remove the pending relationship and add to following and followers if #accept is called' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,8 +15,10 @@ RSpec.configure do |config|
       configuration.following_key = 'following'
       configuration.followers_key = 'followers'
       configuration.blocked_key = 'blocked'
+      configuration.blocked_by_key = 'blocked_by'
       configuration.reciprocated_key = 'reciprocated'
       configuration.pending_key = 'pending'
+      configuration.pending_with_key = 'pending_with'
       configuration.default_scope_key = 'default'
       configuration.pending_follow = false
       configuration.page_size = 25


### PR DESCRIPTION
Howdy!

This pull request adds Amico.clear, which clears all relationships (in either direction) for a user. The motivation for this is that my application allows users to delete their accounts, and I want to prevent orphaned IDs in the various sets (as well as keep the corresponding counts accurate).

In order to be able to clear out blocked and pending sets for other users, I need to add blocked_by and pending_with sets. I didn't create a full API interface for those sets since all I really needed them for was the clear method and I wanted to keep the diff as small as possible. I'm happy to add collection, count, and boolean methods if desired.
