### PR TITLE
Deny pending follow request

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,25 @@ Amico.follower?(1, 11)
 
 Amico.reciprocated?(1, 11)
  => true
+
+Amico.follow(1, 12)
+ => true
+
+Amico.following?(1, 12)
+ => false
+
+Amico.pending?(1, 12)
+ => true
+
+Amico.deny(1, 12)
+ => true
+
+Amico.following?(1, 12)
+ => false
+
+Amico.pending?(1, 12)
+ => false
+
 ```
 
 Use amico with nicknames instead of IDs. NOTE: This could cause you much hardship later on if you allow nicknames to change.
@@ -482,6 +501,8 @@ block(from_id, to_id, scope = Amico.default_scope_key)
 unblock(from_id, to_id, scope = Amico.default_scope_key)
 # Accept a relationship that is pending between two IDs.
 accept(from_id, to_id, scope = Amico.default_scope_key)
+# Deny a relationship that is pending between two IDs.
+deny(from_id, to_id, scope = Amico.default_scope_key)
 # Clear all relationships (in either direction) for a given ID.
 clear(id, scope = Amico.default_scope_key)
 

--- a/lib/amico/relationships.rb
+++ b/lib/amico/relationships.rb
@@ -114,6 +114,25 @@ module Amico
 	  add_following_followers_reciprocated(from_id, to_id, scope)
 	end
 
+	# Deny a relationship that is pending between two IDs.
+	# 
+	# @param from_id [String] The ID of the individual denying the relationship.
+	# @param to_id [String] The ID of the individual to be denied.
+	# @param scope [String] Scope for the call.
+	# 
+	# Example
+	#
+	#   Amico.follow(1, 11)
+	#   Amico.pending?(1, 11) # true
+	#   Amico.deny(1, 11)
+	#   Amico.pending?(1, 11) # false
+	#   Amico.following?(1, 11) #false
+	def deny(from_id, to_id, scope = Amico.default_scope_key)
+		return if from_id == to_id
+		Amico.redis.zrem("#{Amico.namespace}:#{Amico.pending_key}:#{scope}:#{to_id}", from_id)
+		Amico.redis.zrem("#{Amico.namespace}:#{Amico.pending_with_key}:#{scope}:#{from_id}", to_id)
+	end
+
   # Clears all relationships (in either direction) stored for an individual.
   # Helpful to prevent orphaned associations when deleting users.
   # 

--- a/spec/amico/relationships_spec.rb
+++ b/spec/amico/relationships_spec.rb
@@ -635,11 +635,13 @@ describe Amico::Relationships do
       Amico.reciprocated_count(11).should be(0)
     end
     it 'should clear pending/pending_with relationships' do
+      previous_pending_value = Amico.pending_follow
       Amico.pending_follow = true
       Amico.follow(1, 11)
       Amico.pending_count(11).should be(1)
       Amico.clear(1)
       Amico.pending_count(11).should be(0)
+      Amico.pending_follow = previous_pending_value
     end
     it 'should clear blocked/blocked_by relationships' do
       Amico.block(1, 11)

--- a/spec/amico/relationships_spec.rb
+++ b/spec/amico/relationships_spec.rb
@@ -383,6 +383,21 @@ describe Amico::Relationships do
       end
     end
 
+    describe '#deny' do
+      it 'should remove the pending relationship without following or blocking' do
+        Amico.follow(1, 11)
+        Amico.pending?(1, 11).should be_true
+        Amico.pending_with?(11, 1).should be_true
+        
+        Amico.deny(1, 11)
+        
+        Amico.following?(1, 11).should be_false
+        Amico.pending?(1, 11).should be_false
+        Amico.pending_with?(11, 1).should be_false
+        Amico.blocked?(1, 11).should be_false
+      end
+    end
+
     describe '#block' do
       it 'should remove the pending relationship if you block someone' do
         Amico.follow(11, 1)


### PR DESCRIPTION
This pull request adds `Amico.deny`, which removes a pending follow request without blocking or following the pending ID (currently the only ways to remove the ID from the pending set).

Sorry about the flurry of pull requests... I didn't realize I would need this until I started implementing the pending UI in my app this morning. This should be the last one, though :)
