### PR TITLE
Fix issue with add_following_followers_reciprocated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.3.2 (2013-01-04)
+
+* Fixed an issue where the call to `reciprocated?` in the internal method `add_following_followers_reciprocated` was not passing along the scope.
+
 ## 2.3.1 (2012-09-13)
 
 * Wrapped a few operations in Redis multi/exec blocks to be consistent with the rest of the library.

--- a/lib/amico/relationships.rb
+++ b/lib/amico/relationships.rb
@@ -695,7 +695,7 @@ module Amico
     		Amico.redis.zrem("#{Amico.namespace}:#{Amico.pending_with_key}:#{scope}:#{from_id}", to_id)
   	  end
 
-  	  if reciprocated?(from_id, to_id)
+  	  if reciprocated?(from_id, to_id, scope)
     		Amico.redis.multi do
     		  Amico.redis.zadd("#{Amico.namespace}:#{Amico.reciprocated_key}:#{scope}:#{from_id}", Time.now.to_i, to_id)
     		  Amico.redis.zadd("#{Amico.namespace}:#{Amico.reciprocated_key}:#{scope}:#{to_id}", Time.now.to_i, from_id)

--- a/lib/amico/version.rb
+++ b/lib/amico/version.rb
@@ -1,3 +1,3 @@
 module Amico
-  VERSION = '2.3.1'
+  VERSION = '2.3.2'
 end

--- a/spec/amico/relationships_spec.rb
+++ b/spec/amico/relationships_spec.rb
@@ -138,6 +138,17 @@ describe Amico::Relationships do
       Amico.follow(1, 11)
       Amico.reciprocated?(1, 11).should be_false
     end
+
+    it 'should respect scope when checking if a relationship is reciprocated' do
+      Amico.follow(1, 11, 'another_scope')
+      Amico.follow(11, 1, 'another_scope')
+      Amico.follow(1, 11, 'another_scope')
+      Amico.reciprocated?(1, 11).should be_false
+      Amico.reciprocated?(1, 11, 'another_scope').should be_true
+      Amico.follow(1, 11)
+      Amico.follow(11, 1)
+      Amico.reciprocated?(1, 11).should be_true
+    end
   end
 
   describe '#following' do
@@ -388,9 +399,9 @@ describe Amico::Relationships do
         Amico.follow(1, 11)
         Amico.pending?(1, 11).should be_true
         Amico.pending_with?(11, 1).should be_true
-        
+
         Amico.deny(1, 11)
-        
+
         Amico.following?(1, 11).should be_false
         Amico.pending?(1, 11).should be_false
         Amico.pending_with?(11, 1).should be_false
@@ -630,16 +641,16 @@ describe Amico::Relationships do
     it 'should remove follower/following relationships' do
       Amico.follow(1, 11)
       Amico.follow(11, 1)
-      
+
       Amico.following_count(1).should be(1)
       Amico.followers_count(1).should be(1)
       Amico.reciprocated_count(1).should be(1)
       Amico.following_count(11).should be(1)
       Amico.followers_count(11).should be(1)
       Amico.reciprocated_count(11).should be(1)
-      
+
       Amico.clear(1)
-      
+
       Amico.following_count(1).should be(0)
       Amico.followers_count(1).should be(0)
       Amico.reciprocated_count(1).should be(0)
@@ -657,7 +668,7 @@ describe Amico::Relationships do
       Amico.pending_count(11).should be(0)
       Amico.pending_follow = previous_pending_value
     end
-    
+
     it 'should clear blocked/blocked_by relationships' do
       Amico.block(1, 11)
       Amico.blocked_count(1).should be(1)

--- a/spec/amico/version_spec.rb
+++ b/spec/amico/version_spec.rb
@@ -2,6 +2,6 @@ require 'spec_helper'
 
 describe 'Amico::VERSION' do
   it 'should be the correct version' do
-    Amico::VERSION.should == '2.3.1'
+    Amico::VERSION.should == '2.3.2'
   end
 end


### PR DESCRIPTION
- Fixed an issue where the call to `reciprocated?` in the internal method `add_following_followers_reciprocated` was not passing along the scope.
